### PR TITLE
Fix optimistic message ID

### DIFF
--- a/frontend/src/components/chat/ChatWindow.tsx
+++ b/frontend/src/components/chat/ChatWindow.tsx
@@ -80,8 +80,9 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ contactId, contact }) => {
       const previousMessages = queryClient.getQueryData(['messages', contactId])
 
       // Создаем временное сообщение
+      const tempId = Date.now()
       const optimisticMessage = {
-        id: Date.now(), // временный ID
+        id: tempId, // временный ID
         content: variables.content,
         type: variables.type || 'text',
         direction: 'outgoing' as const,
@@ -103,14 +104,14 @@ const ChatWindow: React.FC<ChatWindowProps> = ({ contactId, contact }) => {
         }
       })
 
-      return { previousMessages }
+      return { previousMessages, tempId }
     },
-    onSuccess: (data) => {
+    onSuccess: (data, _variables, context) => {
       // Заменяем optimistic update реальными данными
       queryClient.setQueryData(['messages', contactId], (old: any) => {
         if (!old?.data?.messages) return old
 
-        const messages = old.data.messages.filter((msg: Message) => msg.id !== Date.now())
+        const messages = old.data.messages.filter((msg: Message) => msg.id !== context?.tempId)
         return {
           ...old,
           data: {


### PR DESCRIPTION
## Summary
- track the temporary optimistic ID when sending chat messages
- remove messages using that ID when the server response arrives

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
